### PR TITLE
Use version conditional imports to accomodate mypy

### DIFF
--- a/rdflib/plugin.py
+++ b/rdflib/plugin.py
@@ -37,6 +37,7 @@ from rdflib.query import (
 )
 from rdflib.exceptions import Error
 from typing import Type, TypeVar
+import sys
 
 __all__ = ["register", "get", "plugins", "PluginException", "Plugin", "PKGPlugin"]
 
@@ -110,10 +111,10 @@ def get(name: str, kind: Type[PluginT]) -> Type[PluginT]:
     return p.getClass()
 
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
+if sys.version_info < (3, 8):
     from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 all_entry_points = entry_points()
 if hasattr(all_entry_points, "select"):
@@ -123,7 +124,7 @@ if hasattr(all_entry_points, "select"):
 else:
     # Prior to Python 3.10, this returns a dict instead of the selection interface, which is slightly slower
     for entry_point, kind in rdflib_entry_points.items():
-        for ep in all_entry_points.get(entry_point, []):
+        for ep in all_entry_points.get(entry_point, []):  # type: ignore[union-attr]
             _plugins[(ep.name, kind)] = PKGPlugin(ep.name, kind, ep)
 
 

--- a/rdflib/plugins/sparql/__init__.py
+++ b/rdflib/plugins/sparql/__init__.py
@@ -30,6 +30,7 @@ NotImplementedError if they cannot handle a certain part
 
 PLUGIN_ENTRY_POINT = "rdf.plugins.sparqleval"
 
+import sys
 from . import parser
 from . import operators
 from . import parserutils
@@ -40,10 +41,10 @@ assert parser
 assert operators
 assert parserutils
 
-try:
-    from importlib.metadata import entry_points
-except ImportError:
+if sys.version_info < (3, 8):
     from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 all_entry_points = entry_points()
 if isinstance(all_entry_points, dict):


### PR DESCRIPTION
This will eliminate these errors:

```
+ mypy --show-error-context --show-error-codes rdflib
rdflib/plugin.py:114: error: Module "importlib.metadata" has no attribute "entry_points"  [attr-defined]
rdflib/plugins/sparql/__init__.py:44: error: Module "importlib.metadata" has no attribute "entry_points"  [attr-defined]
Found 2 errors in 2 files (checked 110 source files)
```